### PR TITLE
Feature/challenge list page브렌치

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "docthru_fe",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.7.9",
         "bootstrap": "^5.3.3",
         "lucide-react": "^0.475.0",
         "next": "15.1.6",
@@ -658,6 +659,23 @@
       "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/bootstrap": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
@@ -686,6 +704,19 @@
       },
       "engines": {
         "node": ">=10.16.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/caniuse-lite": {
@@ -765,11 +796,32 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -798,6 +850,197 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/invariant": {
@@ -841,6 +1084,36 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/nanoid": {
@@ -981,6 +1254,12 @@
       "peerDependencies": {
         "react": ">=0.14.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "axios": "^1.7.9",
     "bootstrap": "^5.3.3",
     "lucide-react": "^0.475.0",
     "next": "15.1.6",

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -44,8 +44,8 @@ const getUserMe = async () => {
   return data;
 };
 
-const getChalleges = async () => {
-  const url = "/challenges";
+const getChalleges = async (page = 1) => {
+  const url = `/challenges/?page=${page}`;
   const response = await client.get(url);
   const data = response.data;
   return data;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,62 @@
+const { default: axios } = require("axios");
+
+const baseURL = "http://localhost:5000";
+
+export const client = axios.create({
+  baseURL,
+});
+
+const signUp = async (dto) => {
+  const url = "/auth/signUp";
+  const response = await client.post(url, dto);
+  const data = response.data;
+  return data;
+};
+
+const logIn = async (dto) => {
+  const url = "/auth/logIn";
+  const response = await client.post(url, dto);
+  const data = response.data;
+
+  const { accessToken, refreshToken } = data;
+  client.defaults.headers.Authorization = `Bearer ${accessToken}`;
+  localStorage.setItem("refreshToken", refreshToken);
+
+  return data;
+};
+
+const refreshToken = async (prevRefreshToken) => {
+  const url = "/auth/refreshToken";
+  const response = await client.post(url, {
+    refreshToken: prevRefreshToken,
+  });
+  const data = response.data;
+  const { accessToken, refreshToken: newRefreshToken } = data;
+  client.defaults.headers.Authorization = `Bearer ${accessToken}`;
+  localStorage.setItem("refreshToken", newRefreshToken);
+  return data;
+};
+
+const getUserMe = async () => {
+  const url = "/users/me";
+  const response = await client.get(url);
+  const data = response.data;
+  return data;
+};
+
+const getChalleges = async () => {
+  const url = "/challenges";
+  const response = await client.get(url);
+  const data = response.data;
+  return data;
+};
+
+const api = {
+  signUp,
+  logIn,
+  getUserMe,
+  refreshToken,
+  getChalleges,
+};
+
+export default api;

--- a/src/app/challenges/challenges.module.css
+++ b/src/app/challenges/challenges.module.css
@@ -1,0 +1,62 @@
+.container {
+
+  padding-top: 10px;
+
+  width: 996px;
+  height: 100vh;
+  margin: 0 auto;
+
+  display: flex;
+  flex-direction: column;
+
+  gap: 10px 0px;
+}
+
+
+
+
+.header_main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  /* 필요한 경우 간격 조정 */
+  width: 100%;
+}
+
+.header_title {
+  font-family: Pretendard;
+  font-weight: 600;
+  font-size: 20px;
+  line-height: 23.87px;
+  letter-spacing: 0%;
+}
+
+.searchWrapper {
+  flex: 1;
+}
+
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 24px 0px;
+}
+
+
+.footer {
+  padding-top: 20px;
+  margin: 0 auto;
+  width: 60%;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pageNumber {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  gap: 20px;
+}

--- a/src/app/challenges/my-challenges/[id]/my-challenges.module.css
+++ b/src/app/challenges/my-challenges/[id]/my-challenges.module.css
@@ -12,12 +12,21 @@
   gap: 10px 0px;
 }
 
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px 0px;
+}
+
+
 .header_head {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 10px 20px;
 }
+
+
 
 
 .header_title {
@@ -32,6 +41,45 @@
 .header_head button {
   width: auto;
 }
+
+
+.header_btns {
+  display: flex;
+
+  justify-content: flex-start;
+  align-items: center;
+
+  padding-left: 10px;
+  gap: 0px 5px;
+}
+
+.header_btns button {
+  width: 162px;
+  height: 53px;
+  background-color: white;
+
+  border: none;
+
+  padding: 15px 12px;
+
+  text-align: center;
+  font-family: Pretendard;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 21.48px;
+  letter-spacing: 0%;
+
+  cursor: pointer;
+
+}
+
+.header_btns button:focus {
+  border-bottom: 3px solid black;
+  font-weight: 900;
+
+}
+
+
 
 
 

--- a/src/app/challenges/my-challenges/[id]/page.jsx
+++ b/src/app/challenges/my-challenges/[id]/page.jsx
@@ -1,11 +1,11 @@
 "use client";
 
 import Header from "@/components/Headers/Header";
-import style from "./challenges.module.css";
-import Card from "@/components/Card/Card";
-import Search from "@/components/Search/Search";
+import style from "./my-challenges.module.css";
 import Button from "@/components/Button/Button";
 import { useRouter } from "next/navigation";
+import Search from "@/components/Search/Search";
+import Card from "@/components/Card/Card";
 
 const mockData = [
   {
@@ -38,16 +38,16 @@ const mockData = [
   },
 ];
 
-export default function ChallengesPage() {
+export default function Page() {
   const router = useRouter();
 
   return (
     <>
       <Header />
       <div className={style.container}>
-        <header>
+        <header className={style.header}>
           <div className={style.header_head}>
-            <h2 className={style.header_title}>챌린지 목록</h2>
+            <h2 className={style.header_title}>나의 챌린지</h2>
             <Button
               type={"black"}
               text={"신규 챌린지 신청 +"}
@@ -55,6 +55,11 @@ export default function ChallengesPage() {
                 router.push("/challenges/apply");
               }}
             />
+          </div>
+          <div className={style.header_btns}>
+            <button>참여중인 챌린지</button>
+            <button>완료한 챌린지</button>
+            <button>신청한 챌린지</button>
           </div>
           <div className={style.header_main}>
             {/* 필터 버튼 (필요한 경우 추가) */}

--- a/src/app/challenges/my-challenges/[id]/page.jsx
+++ b/src/app/challenges/my-challenges/[id]/page.jsx
@@ -6,6 +6,7 @@ import Button from "@/components/Button/Button";
 import { useRouter } from "next/navigation";
 import Search from "@/components/Search/Search";
 import Card from "@/components/Card/Card";
+import { useState } from "react";
 
 const mockData = [
   {
@@ -38,8 +39,24 @@ const mockData = [
   },
 ];
 
+const ITEMS_PER_PAGE = 5;
+
 export default function Page() {
   const router = useRouter();
+
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalPages = Math.ceil(mockData.length / ITEMS_PER_PAGE);
+  const paginatedData = mockData.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE
+  );
+
+  const handlePageChange = (page) => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page);
+    }
+  };
 
   return (
     <>
@@ -69,20 +86,35 @@ export default function Page() {
           </div>
         </header>
         <main className={style.main}>
-          {mockData.map((group) => (
+          {paginatedData.map((group) => (
             <Card key={group.id} {...group} />
           ))}
         </main>
         <footer className={style.footer}>
-          <Button type={"page"} text={"<"} />
+          <Button
+            type={"page"}
+            text={"<"}
+            onClick={() => handlePageChange(currentPage - 1)}
+          />
           <div className={style.pageNumber}>
-            <Button type={"page"} text={"1"} />
-            <Button type={"page"} text={"2"} />
-            <Button type={"page"} text={"3"} />
-            <Button type={"page"} text={"4"} />
-            <Button type={"page"} text={"5"} />
+            {/* mockData의 Card 데이터 개수에 따라 버튼 개수 출력 구현부 */}
+            {[...Array(totalPages)].map((_, index) => (
+              <Button
+                key={index + 1}
+                type={
+                  "page" +
+                  `${currentPage === Number(index + 1) ? "Active" : ""}`
+                }
+                text={String(index + 1)}
+                onClick={() => handlePageChange(index + 1)}
+              />
+            ))}
           </div>
-          <Button type={"page"} text={">"} />
+          <Button
+            type={"page"}
+            text={">"}
+            onClick={() => handlePageChange(currentPage + 1)}
+          />
         </footer>
       </div>
     </>

--- a/src/app/challenges/page.jsx
+++ b/src/app/challenges/page.jsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Header from "@/components/Headers/Header";
 import style from "./challenges.module.css";
 import Card from "@/components/Card/Card";
@@ -36,10 +37,48 @@ const mockData = [
     userCount: 3,
     maxUserCount: 7,
   },
+  {
+    id: 5,
+    date: new Date().toLocaleDateString(),
+    title: "같이 배만지기",
+    userCount: 2,
+    maxUserCount: 6,
+  },
+  {
+    id: 6,
+    date: new Date().toLocaleDateString(),
+    title: "같이 배고프기",
+    userCount: 4,
+    maxUserCount: 8,
+  },
+  {
+    id: 7,
+    date: new Date().toLocaleDateString(),
+    title: "같이 배태우기",
+    userCount: 5,
+    maxUserCount: 10,
+  },
 ];
+
+const ITEMS_PER_PAGE = 5;
 
 export default function ChallengesPage() {
   const router = useRouter();
+
+  // 5개씩 카드 출력을 위한 State 와 핸들러 함수 구현부
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalPages = Math.ceil(mockData.length / ITEMS_PER_PAGE);
+  const paginatedData = mockData.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE
+  );
+
+  const handlePageChange = (page) => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page);
+    }
+  };
 
   return (
     <>
@@ -51,33 +90,45 @@ export default function ChallengesPage() {
             <Button
               type={"black"}
               text={"신규 챌린지 신청 +"}
-              onClick={() => {
-                router.push("/challenges/apply");
-              }}
+              onClick={() => router.push("/challenges/apply")}
             />
           </div>
           <div className={style.header_main}>
-            {/* 필터 버튼 (필요한 경우 추가) */}
             <div className={style.searchWrapper}>
               <Search />
             </div>
           </div>
         </header>
         <main className={style.main}>
-          {mockData.map((group) => (
+          {paginatedData.map((group) => (
             <Card key={group.id} {...group} />
           ))}
         </main>
         <footer className={style.footer}>
-          <Button type={"page"} text={"<"} />
+          <Button
+            type={"pageArrow"}
+            text={"<"}
+            onClick={() => handlePageChange(currentPage - 1)}
+          />
           <div className={style.pageNumber}>
-            <Button type={"page"} text={"1"} />
-            <Button type={"page"} text={"2"} />
-            <Button type={"page"} text={"3"} />
-            <Button type={"page"} text={"4"} />
-            <Button type={"page"} text={"5"} />
+            {/* mockData의 Card 데이터 개수에 따라 버튼 개수 출력 구현부 */}
+            {[...Array(totalPages)].map((_, index) => (
+              <Button
+                key={index + 1}
+                type={
+                  "page" +
+                  `${currentPage === Number(index + 1) ? "Active" : ""}`
+                }
+                text={String(index + 1)}
+                onClick={() => handlePageChange(index + 1)}
+              />
+            ))}
           </div>
-          <Button type={"page"} text={">"} />
+          <Button
+            type={"pageArrow"}
+            text={">"}
+            onClick={() => handlePageChange(currentPage + 1)}
+          />
         </footer>
       </div>
     </>

--- a/src/app/challenges/page.jsx
+++ b/src/app/challenges/page.jsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Header from "@/components/Headers/Header";
+import style from "./challenges.module.css";
+import Card from "@/components/Card/Card";
+import Search from "@/components/Search/Search";
+import Button from "@/components/Button/Button";
+
+const mockData = [
+  {
+    id: 1,
+    date: new Date().toLocaleDateString(),
+    title: "점심 같이먹기",
+    userCount: 3,
+    maxUserCount: 7,
+  },
+  {
+    id: 2,
+    date: new Date().toLocaleDateString(),
+    title: "저녁 같이먹기",
+    userCount: 3,
+    maxUserCount: 7,
+  },
+  {
+    id: 3,
+    date: new Date().toLocaleDateString(),
+    title: "아침 같이먹기",
+    userCount: 3,
+    maxUserCount: 7,
+  },
+  {
+    id: 4,
+    date: new Date().toLocaleDateString(),
+    title: "같이 배부르기",
+    userCount: 3,
+    maxUserCount: 7,
+  },
+];
+
+export default function ChallengesPage() {
+  return (
+    <>
+      <Header />
+      <div className={style.container}>
+        <header>
+          <h2 className={style.header_title}>챌린지 목록</h2>
+          <div className={style.header_main}>
+            {/* 필터 버튼 (필요한 경우 추가) */}
+            <div className={style.searchWrapper}>
+              <Search />
+            </div>
+          </div>
+        </header>
+        <main className={style.main}>
+          {mockData.map((group) => (
+            <Card key={group.id} {...group} />
+          ))}
+        </main>
+        <footer className={style.footer}>
+          <Button type={"page"} text={"<"} />
+          <div className={style.pageNumber}>
+            <Button type={"page"} text={"1"} />
+            <Button type={"page"} text={"2"} />
+            <Button type={"page"} text={"3"} />
+            <Button type={"page"} text={"4"} />
+            <Button type={"page"} text={"5"} />
+          </div>
+          <Button type={"page"} text={">"} />
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/src/app/challenges/page.jsx
+++ b/src/app/challenges/page.jsx
@@ -1,75 +1,43 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Header from "@/components/Headers/Header";
 import style from "./challenges.module.css";
 import Card from "@/components/Card/Card";
 import Search from "@/components/Search/Search";
 import Button from "@/components/Button/Button";
 import { useRouter } from "next/navigation";
-
-const mockData = [
-  {
-    id: 1,
-    date: new Date().toLocaleDateString(),
-    title: "점심 같이먹기",
-    userCount: 3,
-    maxUserCount: 7,
-  },
-  {
-    id: 2,
-    date: new Date().toLocaleDateString(),
-    title: "저녁 같이먹기",
-    userCount: 3,
-    maxUserCount: 7,
-  },
-  {
-    id: 3,
-    date: new Date().toLocaleDateString(),
-    title: "아침 같이먹기",
-    userCount: 3,
-    maxUserCount: 7,
-  },
-  {
-    id: 4,
-    date: new Date().toLocaleDateString(),
-    title: "같이 배부르기",
-    userCount: 3,
-    maxUserCount: 7,
-  },
-  {
-    id: 5,
-    date: new Date().toLocaleDateString(),
-    title: "같이 배만지기",
-    userCount: 2,
-    maxUserCount: 6,
-  },
-  {
-    id: 6,
-    date: new Date().toLocaleDateString(),
-    title: "같이 배고프기",
-    userCount: 4,
-    maxUserCount: 8,
-  },
-  {
-    id: 7,
-    date: new Date().toLocaleDateString(),
-    title: "같이 배태우기",
-    userCount: 5,
-    maxUserCount: 10,
-  },
-];
+import api from "@/api/index";
+import React from "react";
 
 const ITEMS_PER_PAGE = 5;
 
 export default function ChallengesPage() {
   const router = useRouter();
 
+  //불러온 데이터 State 변수
+  const [mockChallenges, setChallenges] = useState([]);
+
+  //Api에서 갖고오는 부분
+  const getChallenges = async () => {
+    try {
+      const response = await api.getChalleges();
+      console.log(response); // 응답 데이터 확인
+      setChallenges(response.challenges); // 배열만 저장
+    } catch (error) {
+      console.error("Failed to fetch challenges:", error);
+    }
+  };
+  //Mount 시에만 작동하기
+  useEffect(() => {
+    getChallenges();
+  }, []);
+
   // 5개씩 카드 출력을 위한 State 와 핸들러 함수 구현부
   const [currentPage, setCurrentPage] = useState(1);
 
-  const totalPages = Math.ceil(mockData.length / ITEMS_PER_PAGE);
-  const paginatedData = mockData.slice(
+  const totalPages = Math.ceil(mockChallenges.length / ITEMS_PER_PAGE);
+  const paginatedData = mockChallenges.slice(
     (currentPage - 1) * ITEMS_PER_PAGE,
     currentPage * ITEMS_PER_PAGE
   );

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -11,6 +11,8 @@ const btnTypeArr = [
   { yellow: style.button_yellow },
   { outline_icon: style.button_outline_icon },
   { page: style.button_page },
+  { pageActive: style.button_page_active },
+  { pageArrow: style.button_page_arrow },
   { rightBig: style.button_rightBig },
   { rightSmall: style.button_rightSmall },
   { bottom: style.button_bottom },

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -88,7 +88,35 @@
   border: 0.5px solid gray;
 }
 
+.button_page_arrow {
+  width: 40px;
+  height: 40px;
+  padding: 11.5px 16.5px;
+  color: #a3a3a3;
+
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 16.71px;
+
+  border: 0.5px solid gray;
+}
+
+.button_page_active {
+  width: 40px;
+  height: 40px;
+  padding: 11.5px 16.5px;
+  background-color: #262626;
+  color: #ffc117;
+  border: none;
+}
+
 .button_page:focus {
+  background-color: #262626;
+  color: #ffc117;
+  border: none;
+}
+
+.button_page_arrow:active {
   background-color: #262626;
   color: #ffc117;
   border: none;

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -88,7 +88,7 @@
   border: 0.5px solid gray;
 }
 
-.button_page:active {
+.button_page:focus {
   background-color: #262626;
   color: #ffc117;
   border: none;
@@ -121,7 +121,7 @@
 }
 
 /* 이거 위치조정 해줄 수 있는 분 */
-.button_rightSmall > svg {
+.button_rightSmall>svg {
   position: absolute;
   bottom: 4px;
   right: 4.4px;

--- a/src/components/Chips/Chip.jsx
+++ b/src/components/Chips/Chip.jsx
@@ -1,11 +1,20 @@
 import styles from "./Chip.module.css";
 
-const Chip = ({ type, ...props }) => {
-  const chipStyle = type ? styles[`chip_${type}`] : styles.chip;
+const typeMapping = {
+  modernjs: "Modern JS",
+  web: "Web",
+  api: "API",
+  nextjs: "Next JS",
+  career: "Career",
+};
 
+const Chip = ({ type, ...props }) => {
+  const lowerType = type.toLowerCase();
+  const chipStyle = lowerType ? styles[`chip_${lowerType}`] : styles.lowerType;
+  const label = typeMapping[lowerType] || "";
   return (
     <div className={chipStyle} {...props}>
-      {props.children}
+      {label}
     </div>
   );
 };

--- a/src/components/Headers/Header.module.css
+++ b/src/components/Headers/Header.module.css
@@ -11,6 +11,7 @@
   align-items: center;
   margin-left: 10rem;
 }
+
 .nav {
   display: flex;
 }
@@ -19,6 +20,7 @@
   margin-left: 1rem;
   text-decoration: none;
   color: #333;
+  white-space: nowrap;
 }
 
 .icons {

--- a/src/components/Search/Search.module.css
+++ b/src/components/Search/Search.module.css
@@ -6,7 +6,6 @@
   padding: 10px 16px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   width: 100%;
-  max-width: 400px;
 }
 
 .input {
@@ -16,6 +15,7 @@
   margin-left: 10px;
   flex: 1;
   color: #525252;
+  width: 100%;
 }
 
 .input::placeholder {


### PR DESCRIPTION
- api/index.js 수정

- ChallengesPage의 페이지 네이션 구현 수정

- Card(챨린지)가 5개 이상일시, 5개씩만 보이고, 버튼 1,2,3,4... 누르면 그 다음 챌린지들이 출력되도록 구현

- 위의 구현을 위해 Button 컴포넌트 약간의 수정

- MyChallenge/[id]/page.jsx (나의 체인지)도 마찬가지 5개씩 챌린지 보이도록 수정

- myChallengeListPage 디자인 구현

- ChallengeListPage에서 '신규 챌린지 신청+'버튼 추가

- 나의 챌린지 , 로그아웃 알람창 아직 구현 안돼있어서, 적용X

- 디자인과 구성 컴포넌트 배치

- Header 컴포넌트의 텍스트 링크 화면 줌인아웃시, 줄바꿈 방지 적용

- 필터 버튼 아직없어서 제외
